### PR TITLE
Spanish documentation support

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -1,17 +1,19 @@
 ---
+import { getLanguageFromURL } from '../../languages';
 import MoreMenu from '../RightSidebar/MoreMenu.astro';
 import TableOfContents from '../RightSidebar/TableOfContents.tsx';
 
 const { content, githubEditUrl } = Astro.props;
 const title = content.title;
 const headers = content.astro.headers;
+const lang = getLanguageFromURL(Astro.canonicalURL.pathname)
 ---
 
 <article id="article" class="content">
 	<section class="main-section">
 		<h1 class="content-title" id="overview">{title}</h1>
 		<nav class="block sm:hidden">
-			<TableOfContents client:media="(max-width: 50em)" {headers} />
+			<TableOfContents client:media="(max-width: 50em)" {headers} lang={lang} />
 		</nav>
 		<slot />
 	</section>

--- a/src/components/RightSidebar/MoreMenu.astro
+++ b/src/components/RightSidebar/MoreMenu.astro
@@ -1,11 +1,13 @@
 ---
 import ThemeToggleButton from './ThemeToggleButton.tsx';
 import * as CONFIG from '../../config';
+import { getLanguageFromURL } from '../../languages';
 const { editHref } = Astro.props;
 const showMoreSection = CONFIG.COMMUNITY_INVITE_URL || editHref;
+const lang = getLanguageFromURL(Astro.canonicalURL.pathname)
 ---
 
-{showMoreSection && <h2 class="heading">More</h2>}
+{showMoreSection && <h2 class="heading">{lang === 'en' ? 'More': 'Más'}</h2>}
 <ul>
 	{editHref && (
 		<li class={`header-link depth-2`}>
@@ -51,7 +53,7 @@ const showMoreSection = CONFIG.COMMUNITY_INVITE_URL || editHref;
 						d="M448 0H64C28.7 0 0 28.7 0 64v288c0 35.3 28.7 64 64 64h96v84c0 9.8 11.2 15.5 19.1 9.7L304 416h144c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64z"
 					></path>
 				</svg>
-				<span>Join our community</span>
+				<span>{lang === 'en' ? 'Join our community' : 'Únete a nuestra comunidad'}</span>
 			</a>
 		</li>
 	)}

--- a/src/components/RightSidebar/RightSidebar.astro
+++ b/src/components/RightSidebar/RightSidebar.astro
@@ -1,13 +1,15 @@
 ---
 import TableOfContents from './TableOfContents.tsx';
 import MoreMenu from './MoreMenu.astro';
+import { getLanguageFromURL } from '../../languages';
 const { content, githubEditUrl } = Astro.props;
 const headers = content.astro.headers;
+const lang = getLanguageFromURL(Astro.canonicalURL.pathname)
 ---
 
 <nav class="sidebar-nav" aria-labelledby="grid-right">
 	<div class="sidebar-nav-inner">
-		<TableOfContents client:media="(min-width: 50em)" {headers} />
+		<TableOfContents client:media="(min-width: 50em)" {headers} lang={lang} />
 		<MoreMenu editHref={githubEditUrl} />
 	</div>
 </nav>

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -2,7 +2,7 @@ import type { FunctionalComponent } from 'preact';
 import { h, Fragment } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 
-const TableOfContents: FunctionalComponent<{ headers: any[] }> = ({ headers = [] }) => {
+const TableOfContents: FunctionalComponent<{ headers: any[], lang: string }> = ({ headers = [], lang = 'en' }) => {
 	const itemOffsets = useRef([]);
 	const [activeId, setActiveId] = useState<string>(undefined);
 
@@ -25,10 +25,10 @@ const TableOfContents: FunctionalComponent<{ headers: any[] }> = ({ headers = []
 
 	return (
 		<>
-			<h2 class="heading">On this page</h2>
+			<h2 class="heading">{lang === 'en' ? 'On this page' : 'En esta página'}</h2>
 			<ul>
 				<li class={`header-link depth-2 ${activeId === 'overview' ? 'active' : ''}`.trim()}>
-					<a href="#overview">Overview</a>
+					<a href="#overview">{lang === 'en' ? 'Overview' : 'General'}</a>
 				</li>
 				{headers
 					.filter(({ depth }) => depth > 1 && depth < 4)

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export const OPEN_GRAPH = {
 
 export const KNOWN_LANGUAGES = {
   English: "en",
+  Spanish: "es",
 };
 
 // Uncomment this to add an "Edit this page" button to every page of documentation.
@@ -44,5 +45,16 @@ export const SIDEBAR = {
     { text: "Advanced Usage", link: "en/advanced-usage" },
     { text: "Example", link: "en/example" },
     { text: "Publishing Cakes", link: "en/publishing-cakes" },
+  ],
+  es: [
+    { text: "", header: true },
+    { text: "Información esencial", header: true },
+    { text: "Introducción", link: "es/introduction" },
+    { text: "Instalación", link: "es/installation" },
+    { text: "Usando Cakes", link: "es/using-cakes" },
+    { text: "Creando Cakes", link: "es/creating-cakes" },
+    { text: "Uso Avanzado", link: "es/advanced-usage" },
+    { text: "Ejemplo", link: "es/example" },
+    { text: "Publicando Cakes", link: "es/publishing-cakes" },
   ],
 };

--- a/src/pages/es/advanced-usage.md
+++ b/src/pages/es/advanced-usage.md
@@ -23,27 +23,27 @@ type = "input"
 default = "Prefiero no decirlo"
 ```
 
-- `ques` - The question that will be asked
-- `options` - The options for `select` (will only work with select type)
-- `default` - The default value (will only work with input type)
-- `type` - The type of question
+- `ques` - La pregunta que se hará
+- `options` - Las opciones para `select` (sólo funcionará para el tipo select)
+- `default` - El valor por defecto (sólo funcionará para el tipo input)
+- `type` - El tipo de pregunta
 
-### Types of question
+### Tipos de pregunta
 
-There are two types -
+Existen dos tipos -
 
-- `input` - Input type is normal user input. The answer can be anything.
-- `select` - In select type, the user is given a number of options from which the user has to select one.
-- `menu` - An alias for `select`
+- `input` - El tipo input es la entrada normal de usuario. La respuesta puede ser cualquier cosa.
+- `select` - En el tipo select, se le da al usuario un numéro de opciones de las cuales debe seleccionar una.
+- `menu` - Un alias para `select`
 
-before creating the template. the user will be asked these questions, answers to these questons will be saved.
+Antes de crear la plantilla, el usuario deberá realizar las preguntas y las respuestas serán guardadas
 
-## Creating files based on answers
+## Creando ficheros u archivos basados en preguntas
 
-Remember the `true` value that you have to put if you want a file to be created? Now you can use a templating language to return `true` or `false` based on the answers you get.
+¿Recuerdas el valor `true` que debes ingresar si quieres que un fichero o archivo sea creado? Ahora puedes usar el lenguaje de plantillas para retornar `true` o `false` basándote en la respuesta que obtengas.
 
 ```toml
-"apple" = '''
+"manzana" = '''
 {{if eq (index . "id") "value"}}
   true
 {{else}}
@@ -52,9 +52,9 @@ Remember the `true` value that you have to put if you want a file to be created?
 '''
 ```
 
-> The `id` here is the id of the question. and the `value` is the value that the answer of the question should be compared with
+> El `id` aquí es el id de la pregunta. Y el `value` es el valor con el que se debe comparar la respuesta a la pregunta
 
-This is equivalent to :-
+Esto es equivalente a :-
 
 ```js
 if (answers["id"] == "value") {
@@ -64,11 +64,11 @@ if (answers["id"] == "value") {
 }
 ```
 
-You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+Puedes aprender más acerca del lenguaje de plantillas [aquí](https://pkg.go.dev/text/template)
 
-## Dynamic file contents
+## Contenido de fichero dinámico
 
-You can use the same templating language for dynamic content
+Puedes usar el mismo lenguaje de plantillas para crear contenido dinámico
 
 ```toml
 [contents]
@@ -79,9 +79,9 @@ You can use the same templating language for dynamic content
 '''
 ```
 
-> Here `name` is the id of the question
+> Aquí `name` es el id de la pregunta
 
-JS doc string equivalent :-
+Equivalente de la documentación de JS con string:-
 
 ```js
 `{
@@ -89,11 +89,11 @@ JS doc string equivalent :-
 }`;
 ```
 
-You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+Puedes aprender más acerca del lenguaje de plantillas [aquí](https://pkg.go.dev/text/template)
 
-## Running commands based on answers
+## Corriendo comandos basados en respuestas
 
-You can also use the templating language to return `true` or `false`. If the return is `true`, the command will be invoked.
+Puedes usar el mismo lenguaje de plantillas para retornar `true` o `false`. Si la respuesta es `true`, el comando será invocado
 
 ```toml
 [commands]
@@ -106,9 +106,9 @@ You can also use the templating language to return `true` or `false`. If the ret
 '''
 ```
 
-> Here `id` is the question's id and `value` is the answer that's being compared with
+> Aquí `id` es el id de la pregunta y el `value` es la respuesta con la que se compara
 
-This is equivalent to :-
+Esto es equivalente a :-
 
 ```js
 if (answers["id"] == "value") {
@@ -118,8 +118,8 @@ if (answers["id"] == "value") {
 }
 ```
 
-You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+Puedes aprender más acerca del lenguaje de plantillas [aquí](https://pkg.go.dev/text/template)
 
-## Finishing off
+## Cerrando la sección
 
-There are more cool features to come, so stay tuned.
+Vienen nuevos features en camino, así que mantente en sintonía.

--- a/src/pages/es/advanced-usage.md
+++ b/src/pages/es/advanced-usage.md
@@ -1,0 +1,125 @@
+---
+title: Uso Avanzado
+description: Cakecutter | Uso Avanzado
+layout: ../../layouts/MainLayout.astro
+---
+
+Es posible que aún prefieras un cli personalizado dado que puedes usar alguna biblioteca de interfaz de usuario de terminal elegante para hacer preguntas basadas en los archivos que crees. ¿Sabías que cakecutter también puede hacer eso? ¿No es genial?
+
+
+## Realizar preguntas
+
+Puedes realizar preguntas adhiriendo un atributo en la tabla `[questions]`:-
+
+```toml
+[[questions.a]] # <- El id que escribas aquí será usado para devolver las respuestas
+ques = "Te gusta la Manzana o el Mango"
+type = "select"
+options = ["Manzana", "Mango"]
+
+[[questions.name]]
+ques = "¿Cuál es tu nombre?"
+type = "input"
+default = "Prefiero no decirlo"
+```
+
+- `ques` - The question that will be asked
+- `options` - The options for `select` (will only work with select type)
+- `default` - The default value (will only work with input type)
+- `type` - The type of question
+
+### Types of question
+
+There are two types -
+
+- `input` - Input type is normal user input. The answer can be anything.
+- `select` - In select type, the user is given a number of options from which the user has to select one.
+- `menu` - An alias for `select`
+
+before creating the template. the user will be asked these questions, answers to these questons will be saved.
+
+## Creating files based on answers
+
+Remember the `true` value that you have to put if you want a file to be created? Now you can use a templating language to return `true` or `false` based on the answers you get.
+
+```toml
+"apple" = '''
+{{if eq (index . "id") "value"}}
+  true
+{{else}}
+  false
+{{end}}
+'''
+```
+
+> The `id` here is the id of the question. and the `value` is the value that the answer of the question should be compared with
+
+This is equivalent to :-
+
+```js
+if (answers["id"] == "value") {
+  return true;
+} else {
+  return false;
+}
+```
+
+You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+
+## Dynamic file contents
+
+You can use the same templating language for dynamic content
+
+```toml
+[contents]
+"test.json" = '''
+{
+  "name": "{{index . "name"}}"
+}
+'''
+```
+
+> Here `name` is the id of the question
+
+JS doc string equivalent :-
+
+```js
+`{
+  "name": "${answers["name"]}"
+}`;
+```
+
+You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+
+## Running commands based on answers
+
+You can also use the templating language to return `true` or `false`. If the return is `true`, the command will be invoked.
+
+```toml
+[commands]
+"npm init -y" = '''
+{{if eq (index . "id") "value"}}
+  true
+{{else}}
+  false
+{{end}}
+'''
+```
+
+> Here `id` is the question's id and `value` is the answer that's being compared with
+
+This is equivalent to :-
+
+```js
+if (answers["id"] == "value") {
+  return "true";
+} else {
+  return "false";
+}
+```
+
+You can learn more about the templating language [here](https://pkg.go.dev/text/template)
+
+## Finishing off
+
+There are more cool features to come, so stay tuned.

--- a/src/pages/es/advanced-usage.md
+++ b/src/pages/es/advanced-usage.md
@@ -38,7 +38,7 @@ Existen dos tipos -
 
 Antes de crear la plantilla, el usuario deberá realizar las preguntas y las respuestas serán guardadas
 
-## Creando ficheros u archivos basados en preguntas
+## Creando ficheros u archivos basados en respuestas
 
 ¿Recuerdas el valor `true` que debes ingresar si quieres que un fichero o archivo sea creado? Ahora puedes usar el lenguaje de plantillas para retornar `true` o `false` basándote en la respuesta que obtengas.
 

--- a/src/pages/es/creating-cakes.md
+++ b/src/pages/es/creating-cakes.md
@@ -39,7 +39,7 @@ Dirígete a la sección de [`Uso Avanzado`](/es/advanced-usage) para más inform
 
 ## Estructura del fichero
 
-Para crear un archivo/directorio, pon el nombre en la tabla `[filestructure]` como key, y el `true` como valor.
+Para crear un archivo/directorio, pon el nombre en la tabla `[filestructure]` como key, y `true` como valor.
 
 ```toml
 [filestructure]

--- a/src/pages/es/creating-cakes.md
+++ b/src/pages/es/creating-cakes.md
@@ -1,0 +1,100 @@
+---
+title: Creating Cakes
+description: Cakecutter | Creating Cakes
+layout: ../../layouts/MainLayout.astro
+---
+
+> All template files are in [`.toml`](https://toml.io/en/) format, which are easy to edit and share with others.
+
+## Cake Metadata
+
+Cake metadata consists of only two properties :-
+
+- `name` :- The name of the cake
+- `description` :- The description of the cake
+
+### Example
+
+```toml
+[metadata]
+name = "cakecutter"
+description = "A cool description"
+```
+
+## Folding the Batter
+
+Batter are the commands which are run before creating all the files.
+
+```toml
+[batter]
+1 = [
+  "git init", "true"
+]
+2 = [
+  "go mod init", "true"
+]
+```
+
+The reason true is there is because it tells `cakecutter` to run this, its needs to be there, or else the command won't be invoked.
+Head to [`Advanced Usage`](/en/advanced-usage) section for more information.
+
+## File Structure
+
+To create a file/directory put the it's name in `[filestructure]` table as the key with the value `true`
+
+```toml
+[filestructure]
+"main.go" = "true"
+"bin/" = "true" # << To create a directory put / in the end
+```
+
+The value `true` tells `cakecutter` to create this; if the value does not contain `true` it won't create the file/dir.
+The reason it's like this is because of dynamic `filestructure`. While creating the template, `cakecutter` will ask some questions configured by the cake author, based on their answers, the files are created.
+To configure questions head to [`Advanced Usage`](/en/advanced-usage) section.## File Content
+
+To add content to a file, put its name in `[content]` table as the key with its contents as the value
+
+```toml
+[content]
+"main.go" = '''
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hi mom")
+}
+'''
+```
+
+> Note: You can use multiline strings using 3 quotes `""" """`
+
+Dynamic content is also possible by templating. head to [`Advanced Usage`]('/en/advanced-usage') section for more information.
+
+## Sprinkling some toppings
+
+Toppings are just like batter, but instead of running before everything, they are run after everything to complete the setup.
+
+```toml
+[toppings]
+1 = [
+  "go mod init example.com/hello", "true"
+]
+2 = [
+  "go build -o bin/cakecutter.exe" = "true"
+]
+```
+
+## Finishing off
+
+The cake is done, save the file , and run
+
+```
+cc local <path-to-the-file.toml> <directory>
+```
+
+> `directory` is the name of directory where the template will be created
+
+The template should be created in that directory.<br>
+
+Head to [`How to publish a cake`](/en/publishing-cakes) section if you wanna publish this cake for everyone's use.

--- a/src/pages/es/creating-cakes.md
+++ b/src/pages/es/creating-cakes.md
@@ -21,7 +21,7 @@ name = "cakecutter"
 description = "Una descripción genial"
 ```
 
-## Doblando la Mantequilla
+## Doblando la Mantequilla (Folding the butter)
 
 Batter (o Mantenquilla en español) son los comandos que se corren antes de la creación de ficheros u archivos.
 

--- a/src/pages/es/creating-cakes.md
+++ b/src/pages/es/creating-cakes.md
@@ -1,29 +1,29 @@
 ---
-title: Creating Cakes
-description: Cakecutter | Creating Cakes
+title: Creando Cakes
+description: Cakecutter | Creando Cakes
 layout: ../../layouts/MainLayout.astro
 ---
 
-> All template files are in [`.toml`](https://toml.io/en/) format, which are easy to edit and share with others.
+> Todos los archivos de plantillas están en formato [`.toml`](https://toml.io/en/), lo cual hace fácil editar y compartir con otras personas.
 
-## Cake Metadata
+## El Metadata de Cake
 
-Cake metadata consists of only two properties :-
+El Metadata de Cake consiste en dos propiedades :-
 
-- `name` :- The name of the cake
-- `description` :- The description of the cake
+- `name` :- El nombre de la cake
+- `description` :- La descripción de la cake
 
-### Example
+### Ejemplo
 
 ```toml
 [metadata]
 name = "cakecutter"
-description = "A cool description"
+description = "Una descripción genial"
 ```
 
-## Folding the Batter
+## Doblando la Mantequilla
 
-Batter are the commands which are run before creating all the files.
+Batter (o Mantenquilla en español) son los comandos que se corren antes de la creación de ficheros u archivos.
 
 ```toml
 [batter]
@@ -34,25 +34,27 @@ Batter are the commands which are run before creating all the files.
   "go mod init", "true"
 ]
 ```
+La razón de que `true` esté ahí es porque le indica a `cakecutter` corre esto, tiene que estar ahí, de lo contrario el comando no será invocado.
+Dirígete a la sección de [`Uso Avanzado`](/es/advanced-usage) para más información.
 
-The reason true is there is because it tells `cakecutter` to run this, its needs to be there, or else the command won't be invoked.
-Head to [`Advanced Usage`](/en/advanced-usage) section for more information.
+## Estructura del fichero
 
-## File Structure
-
-To create a file/directory put the it's name in `[filestructure]` table as the key with the value `true`
+Para crear un archivo/directorio, pon el nombre en la tabla `[filestructure]` como key, y el `true` como valor.
 
 ```toml
 [filestructure]
 "main.go" = "true"
-"bin/" = "true" # << To create a directory put / in the end
+"bin/" = "true" # << Para crear un directorio, pon / al final
 ```
 
-The value `true` tells `cakecutter` to create this; if the value does not contain `true` it won't create the file/dir.
-The reason it's like this is because of dynamic `filestructure`. While creating the template, `cakecutter` will ask some questions configured by the cake author, based on their answers, the files are created.
-To configure questions head to [`Advanced Usage`](/en/advanced-usage) section.## File Content
+El valor `true` le indica a `cakecutter` que cree esto; si el valor no contiene `true`, no se creará el fichero/directorio.
+La razón de este comportamiento es debido al dinamismo de `filestructure`. Mientras se crea la plantilla, `cakecutter` hará preguntas al autor de la cake. En base a sus respuestas, los ficheros son creados.
 
-To add content to a file, put its name in `[content]` table as the key with its contents as the value
+Para la configuración de preguntas, dirígete a la sección de [`Uso Avanzado`](/es/advanced-usage).
+
+## Contenido del fichero
+
+Para crear contenido en un fichero, pon el nombre de éste en la tabla `[content]` como la key y el contenido como valor.
 
 ```toml
 [content]
@@ -62,18 +64,19 @@ package main
 import "fmt"
 
 func main() {
-  fmt.Println("Hi mom")
+  fmt.Println("Hola mamá")
 }
 '''
 ```
 
-> Note: You can use multiline strings using 3 quotes `""" """`
+> Nota: Puedes usar cadenas de texto multilínea mediante 3 comillas dobles `""" """`
 
-Dynamic content is also possible by templating. head to [`Advanced Usage`]('/en/advanced-usage') section for more information.
+Contenido dinámico es también posible mediante lenguaje de plantillas. Dirígete a la sección de [`Uso Avanzado`]('/es/advanced-usage') para más información.
 
-## Sprinkling some toppings
+## Espolvorear algunos ingredientes adicionales
 
-Toppings are just like batter, but instead of running before everything, they are run after everything to complete the setup.
+Los ingredientes adicionales (toppings) son como la mantequilla o butter, pero con la diferencia de que se corren luego de que el setup esté completo.
+
 
 ```toml
 [toppings]
@@ -85,16 +88,16 @@ Toppings are just like batter, but instead of running before everything, they ar
 ]
 ```
 
-## Finishing off
+## Cerrando la sección
 
-The cake is done, save the file , and run
+La cake está terminada, guarda todo y sólo corre
 
 ```
 cc local <path-to-the-file.toml> <directory>
 ```
 
-> `directory` is the name of directory where the template will be created
+> `directory` es el nombre del directorio donde la plantilla va a ser creada
 
-The template should be created in that directory.<br>
+La plantilla debe ser creada en ese directorio.<br>
 
-Head to [`How to publish a cake`](/en/publishing-cakes) section if you wanna publish this cake for everyone's use.
+Dirígete a la sección de [`Cómo publicar una cake`](/es/publishing-cakes) si quieres que la cake sea usada por todos.

--- a/src/pages/es/example.md
+++ b/src/pages/es/example.md
@@ -1,0 +1,27 @@
+---
+title: Example
+description: Cakecutter | Example
+layout: ../../layouts/MainLayout.astro
+---
+
+### Basic Example Cake
+
+Here is a basic cake which asks for the user's name and creates a file with their name as the content
+
+```toml
+[metadata]
+name = "name-printer"
+description = "Prints your name to a file in seconds!" # XD
+
+[[questions.name]]
+ques = "What is your name?"
+type = "input"
+
+[filestructure]
+"name.txt" = "true"
+
+[content]
+"name.txt" = '''
+{{index .Ans "name"}}
+'''
+```

--- a/src/pages/es/example.md
+++ b/src/pages/es/example.md
@@ -1,20 +1,20 @@
 ---
-title: Example
-description: Cakecutter | Example
+title: Ejemplo
+description: Cakecutter | Ejemplo
 layout: ../../layouts/MainLayout.astro
 ---
 
-### Basic Example Cake
+### Ejemplo básico de una Cake
 
-Here is a basic cake which asks for the user's name and creates a file with their name as the content
+Aquí verás un ejemplo básico de una cake que pregunta por el nombre de usuario y crea un fichero cuyo contenido será el nombre de dicho usuario.
 
 ```toml
 [metadata]
 name = "name-printer"
-description = "Prints your name to a file in seconds!" # XD
+description = "Muestra tu nombre en el fichero en segundos!" # XD
 
 [[questions.name]]
-ques = "What is your name?"
+ques = "¿Cuál es tu nombre?"
 type = "input"
 
 [filestructure]

--- a/src/pages/es/installation.md
+++ b/src/pages/es/installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+description: Cakecutter | Installation
+layout: ../../layouts/MainLayout.astro
+---
+
+## Using Go
+
+If you have Go installed, you can install cakecutter directly from source.
+
+```
+go install github.com/cake-cutter/cc@latest
+```
+
+## Using npm
+
+You can also use npm -
+
+<details>
+  <summary>For Windows</summary>
+
+```
+npm install -g cakecutter
+```
+
+</details>
+
+<details>
+  <summary>For MacOS</summary>
+
+```
+npm install -g cc-for-mac
+```
+
+</details>
+
+<details>
+  <summary>For Linux</summary>
+
+```
+npm install -g cc-for-linux
+```
+
+</details>
+
+> Cakecutter hasn't been tested on MacOS and Linux, please open an [issue](https://github.com/cake-cutter/cc/issues/new/choose) if you come across a bug.
+
+## Using binary executables
+
+Download the binary executables from the <a href="https://github.com/cake-cutter/cc/tree/master/bin" target="_blank">repository</a>.

--- a/src/pages/es/installation.md
+++ b/src/pages/es/installation.md
@@ -1,23 +1,23 @@
 ---
-title: Installation
-description: Cakecutter | Installation
+title: Instalación
+description: Cakecutter | Instalación
 layout: ../../layouts/MainLayout.astro
 ---
 
-## Using Go
+## Usando Go
 
-If you have Go installed, you can install cakecutter directly from source.
+Si tienes Go instalado, puedes instalar cakecutter desde su fuente.
 
 ```
 go install github.com/cake-cutter/cc@latest
 ```
 
-## Using npm
+## Usando npm
 
-You can also use npm -
+Puedes usar npm -
 
 <details>
-  <summary>For Windows</summary>
+  <summary>Para Windows</summary>
 
 ```
 npm install -g cakecutter
@@ -26,7 +26,7 @@ npm install -g cakecutter
 </details>
 
 <details>
-  <summary>For MacOS</summary>
+  <summary>Para MacOS</summary>
 
 ```
 npm install -g cc-for-mac
@@ -35,7 +35,7 @@ npm install -g cc-for-mac
 </details>
 
 <details>
-  <summary>For Linux</summary>
+  <summary>Para Linux</summary>
 
 ```
 npm install -g cc-for-linux
@@ -43,8 +43,9 @@ npm install -g cc-for-linux
 
 </details>
 
-> Cakecutter hasn't been tested on MacOS and Linux, please open an [issue](https://github.com/cake-cutter/cc/issues/new/choose) if you come across a bug.
+> Cakecutter no fue testeado en MacOS ni en Linux, abre una [incidencia](https://github.com/cake-cutter/cc/issues/new/choose) si te encuentras con algo que no funcione bien.
 
-## Using binary executables
 
-Download the binary executables from the <a href="https://github.com/cake-cutter/cc/tree/master/bin" target="_blank">repository</a>.
+## Usando binarios ejecutables
+
+Descarga el binario ejecutable desde este <a href="https://github.com/cake-cutter/cc/tree/master/bin" target="_blank">repositorio</a>.

--- a/src/pages/es/introduction.md
+++ b/src/pages/es/introduction.md
@@ -1,39 +1,39 @@
 ---
-title: Introduction
+title: Introducción
 description: Docs intro
 layout: ../../layouts/MainLayout.astro
 ---
 
-### 👀 What is Cakecutter?
-Sometimes, the most difficult thing is to just get started with a project. Cakecutter is a tool that helps you to cut the cake and start your amazing project instantly. 
+### 👀 ¿Qué es Cakecutter?
+Algunas veces, lo más difícil es empezar con un proyecto. Cakecutter es una herramienta que te ayuda a cortar la torta (cut the cake en inglés) y empezar tu proyecto instantáneamente.
 
-What Cakecutter does:
-- Users can [publish](/en/publishing-cakes/), [create](/en/creating-cakes/) or [use a cake](/en/using-cakes) from [Cakes.run](https://cakes.run). Cakes are basically TOML files which contain all the information needed to create a project. 
-- According to the information in the `Cakefile`, Cakecutter will create all the files and (you can also fill them with content) in the correct location.
-- Setup commands (installing dependencies, etc) can be defined in the `Cakefile`. These commands are run after the files are generated.
-- Cakecutter can ask questions to the user and take input. The input can then be used as variables for the project template. [Read the docs here](/en/advance-usage)
+Lo que Cakecutter es capaz de hacer:
+- Usuarios pueden [publicar](/es/publishing-cakes/), [crear](/es/creating-cakes/) o [usar una cake](/es/using-cakes) desde [Cakes.run](https://cakes.run). Cakes son básicamente ficheros TOML files que contienen toda la información que se necesita para crear un proyecto. 
+- Según la información en el fichero `Cakefile`, Cakecutter creará todos los ficheros (tú puedes crear el contenido de ellos) en la ubicación correcta.
+- Comandos de setup (instalar dependencias, etcétera) pueden ser definidos en el fichero `Cakefile`. Estos comandos se corren luego de que los ficheros son generados.
+- Cakecutter puede realizar preguntas al uduario y tomar sus respuestas. Dichas respuestas luego pueden ser utilizadas como variables en la plantilla del proyecto. [Lee la documentación aquí](/es/advance-usage)
 
-## Documentation
+## Documentación
 
-- [Installating the CLI](/en/installation)
+- [Instalando la terminal CLI](/es/installation)
 
-- [Using cakes](/en/using-cakes)
+- [Usando cakes](/es/using-cakes)
 
-- [Creating a cake](/en/creating-cakes)
+- [Creando una cake](/es/creating-cakes)
 
-  - [Cake Metadata](/en/creating-cakes/#cake-metadata)
-  - [Folding the Batter](/en/creating-cakes/#folding-the-batter)
-  - [File Strucuture](/en/creating-cakes/#file-structure)
-  - [File Content](/en/creating-cakes/#file-content)
-  - [Sprinkling some toppings](/en/creating-cakes/#sprinkling-some-toppings)
+  - [El Metadata de Cake](/es/creating-cakes/#el-metadata-de-cake)
+  - [Doblando la Mantequilla (Folding the butter)](/es/creating-cakes/#doblando-la-mantequilla-folding-the-butter)
+  - [Estructura de fichero](/es/creating-cakes#estructura-del-fichero)
+  - [Contenido de fichero](/es/creating-cakes#contenido-del-fichero)
+  - [Espolvorear algunos ingredientes adicionales](/es/creating-cakes#espolvorear-algunos-ingredientes-adicionales)
 
-- [Advanced Usage](/en/advanced-usage)
+- [Uso Avanzado](/es/advanced-usage)
 
-  - [Asking questions](/en/advanced-usage/#asking-questions)
-  - [Creating files based on answers](/en/advanced-usage/#creating-files-based-on-answers)
-  - [Dyanmic file contents](/en/advanced-usage/#dynamic-file-contents)
-  - [Running commands based on answers](/en/advanced-usage/#running-commands-based-on-answers)
+  - [Realizar preguntas](/es/advanced-usage#realizar-preguntas)
+  - [Creando ficheros u archivos basados en respuestas](/es/advanced-usage#creando-ficheros-u-archivos-basados-en-respuestas)
+  - [Contenido dinámico de ficheros](/es/advanced-usage#contenido-de-fichero-dinámico)
+  - [Corriendo comandos basados en respuestas](/es/advanced-usage#corriendo-comandos-basados-en-respuestas)
 
-- [Basic Example Cake](/en/example)
+- [Ejemplo básico de una Cake](/es/example)
 
-- [Publishing a cake for everyone's use](/en/publishing-cakes)
+- [Publicar una cake para que la puedan usar todos](/es/publishing-cakes)

--- a/src/pages/es/introduction.md
+++ b/src/pages/es/introduction.md
@@ -8,7 +8,7 @@ layout: ../../layouts/MainLayout.astro
 Algunas veces, lo más difícil es empezar con un proyecto. Cakecutter es una herramienta que te ayuda a cortar la torta (cut the cake en inglés) y empezar tu proyecto instantáneamente.
 
 Lo que Cakecutter es capaz de hacer:
-- Usuarios pueden [publicar](/es/publishing-cakes/), [crear](/es/creating-cakes/) o [usar una cake](/es/using-cakes) desde [Cakes.run](https://cakes.run). Cakes son básicamente ficheros TOML files que contienen toda la información que se necesita para crear un proyecto. 
+- Usuarios pueden [publicar](/es/publishing-cakes/), [crear](/es/creating-cakes/) o [usar una cake](/es/using-cakes) desde [Cakes.run](https://cakes.run). Cakes son básicamente ficheros TOML que contienen toda la información que se necesita para crear un proyecto. 
 - Según la información en el fichero `Cakefile`, Cakecutter creará todos los ficheros (tú puedes crear el contenido de ellos) en la ubicación correcta.
 - Comandos de setup (instalar dependencias, etcétera) pueden ser definidos en el fichero `Cakefile`. Estos comandos se corren luego de que los ficheros son generados.
 - Cakecutter puede realizar preguntas al uduario y tomar sus respuestas. Dichas respuestas luego pueden ser utilizadas como variables en la plantilla del proyecto. [Lee la documentación aquí](/es/advance-usage)

--- a/src/pages/es/introduction.md
+++ b/src/pages/es/introduction.md
@@ -1,0 +1,39 @@
+---
+title: Introduction
+description: Docs intro
+layout: ../../layouts/MainLayout.astro
+---
+
+### 👀 What is Cakecutter?
+Sometimes, the most difficult thing is to just get started with a project. Cakecutter is a tool that helps you to cut the cake and start your amazing project instantly. 
+
+What Cakecutter does:
+- Users can [publish](/en/publishing-cakes/), [create](/en/creating-cakes/) or [use a cake](/en/using-cakes) from [Cakes.run](https://cakes.run). Cakes are basically TOML files which contain all the information needed to create a project. 
+- According to the information in the `Cakefile`, Cakecutter will create all the files and (you can also fill them with content) in the correct location.
+- Setup commands (installing dependencies, etc) can be defined in the `Cakefile`. These commands are run after the files are generated.
+- Cakecutter can ask questions to the user and take input. The input can then be used as variables for the project template. [Read the docs here](/en/advance-usage)
+
+## Documentation
+
+- [Installating the CLI](/en/installation)
+
+- [Using cakes](/en/using-cakes)
+
+- [Creating a cake](/en/creating-cakes)
+
+  - [Cake Metadata](/en/creating-cakes/#cake-metadata)
+  - [Folding the Batter](/en/creating-cakes/#folding-the-batter)
+  - [File Strucuture](/en/creating-cakes/#file-structure)
+  - [File Content](/en/creating-cakes/#file-content)
+  - [Sprinkling some toppings](/en/creating-cakes/#sprinkling-some-toppings)
+
+- [Advanced Usage](/en/advanced-usage)
+
+  - [Asking questions](/en/advanced-usage/#asking-questions)
+  - [Creating files based on answers](/en/advanced-usage/#creating-files-based-on-answers)
+  - [Dyanmic file contents](/en/advanced-usage/#dynamic-file-contents)
+  - [Running commands based on answers](/en/advanced-usage/#running-commands-based-on-answers)
+
+- [Basic Example Cake](/en/example)
+
+- [Publishing a cake for everyone's use](/en/publishing-cakes)

--- a/src/pages/es/publishing-cakes.md
+++ b/src/pages/es/publishing-cakes.md
@@ -1,0 +1,37 @@
+---
+title: Publishing Cakes
+description: Cakecutter | Publishing Cakes
+layout: ../../layouts/MainLayout.astro
+---
+
+## Logging in
+
+You need to login before you can publish a package.
+
+```
+cc login
+```
+
+After you have logged in. You can publish the cake!
+
+## Creating a README
+
+You need to create a `README` file. It contains details about the cake and it will also appear on the website so it should be nice.
+
+## Finding a name thats not taken
+
+If a cake with the same name exists. You won't be able to publish a cake with the same name (unless you own that cake). So please make sure that the name is not taken and then publish
+
+## Publishing
+
+To publish a cake you can use the `publish` command.
+
+```
+cc publish <cake.toml>
+```
+
+> here `cake.toml` is the path of the `cake` you wanna publish
+
+## Updating the cake
+
+You can update the cake by using the same command. The cake will be replaced with the new one.

--- a/src/pages/es/publishing-cakes.md
+++ b/src/pages/es/publishing-cakes.md
@@ -16,7 +16,7 @@ Luego de acceder, ¡puedes publicar la cake!
 
 ## Crear el fichero README
 
-El fichero `README` file contiene los detalles de la cake y, además, aparecerá en tu sitio web, lo que es genial.
+El fichero `README` contiene los detalles de la cake y, además, aparecerá en tu sitio web, lo que es genial.
 
 ## Encontrar un nombre que no esté en uso
 

--- a/src/pages/es/publishing-cakes.md
+++ b/src/pages/es/publishing-cakes.md
@@ -1,37 +1,37 @@
 ---
-title: Publishing Cakes
-description: Cakecutter | Publishing Cakes
+title: Publicar Cakes
+description: Cakecutter | Publicar Cakes
 layout: ../../layouts/MainLayout.astro
 ---
 
-## Logging in
+## Acceso
 
-You need to login before you can publish a package.
+Tienes que acceder a tu cuenta antes de publicar una cake.
 
 ```
 cc login
 ```
 
-After you have logged in. You can publish the cake!
+Luego de acceder, ¡puedes publicar la cake!
 
-## Creating a README
+## Crear el fichero README
 
-You need to create a `README` file. It contains details about the cake and it will also appear on the website so it should be nice.
+El fichero `README` file contiene los detalles de la cake y, además, aparecerá en tu sitio web, lo que es genial.
 
-## Finding a name thats not taken
+## Encontrar un nombre que no esté en uso
 
-If a cake with the same name exists. You won't be able to publish a cake with the same name (unless you own that cake). So please make sure that the name is not taken and then publish
+Si una cake con el mismo nombre existe, no podrás publicar la cake (a menos que seas dueño de esa cake). Por eso, asegúrate que el nombre no esté en uso y luego, procede a publicar tu cake
 
-## Publishing
+## Publicación
 
-To publish a cake you can use the `publish` command.
+Para publicar una cake, corre el comando `publish`.
 
 ```
 cc publish <cake.toml>
 ```
 
-> here `cake.toml` is the path of the `cake` you wanna publish
+> Aquí `cake.toml` es la ruta de la `cake` que quieres publicar
 
-## Updating the cake
+## Actualizar la cake
 
-You can update the cake by using the same command. The cake will be replaced with the new one.
+Puedes actualizar la cake utilizando el mismo comando. La cake será reemplazada con la nueva.

--- a/src/pages/es/using-cakes.md
+++ b/src/pages/es/using-cakes.md
@@ -1,34 +1,34 @@
 ---
-title: Using Cakes
-description: Cakecutter | Using Cakes
+title: Usando Cakes
+description: Cakecutter | Usando Cakes
 layout: ../../layouts/MainLayout.astro
 ---
 
-## Online cakes
+## Cakes en línea
 
-After installing `cakecutter` you can run
+Luego de instalar `cakecutter` puede correr
 
 ```
 cc cut <cake> <dir>
 ```
 
-> `<cake>` is the cake's name and `<dir>` is the directory where the template will be created
+> `<cake>` es el nombre de la cake y `<dir>` es el directorio donde la plantilla será creada
 
-to cut an online cake
+Para cortar una torta o cake en línea
 
-## Local cakes
+## Cakes locales
 
-You can cut local cakes written in [`toml`](https://toml.io/) syntax files by running
+Puedes cortar tus cakes o tortas locales escritas en sintaxis [`toml`](https://toml.io/) corriendo
 
 ```
 cc local <cake.toml> <dir>
 ```
 
-> `cake.toml` is the path to the local cake file and `dir` is the directory where the template will be created
+> `cake.toml` es la ruta a la cake local y  `dir` es el directorio donde la plantilla será creada
 
-## With npx
+## Con npx
 
-If you are using cakecutter through `npx` then just prefix the command with `npx`.
+Si estás utilizando cakecutter a través de `npx`, entonces utiliza `npx` como prefijo a los comandos
 
 ```
 npx cc cut <cake> <dir>

--- a/src/pages/es/using-cakes.md
+++ b/src/pages/es/using-cakes.md
@@ -1,0 +1,35 @@
+---
+title: Using Cakes
+description: Cakecutter | Using Cakes
+layout: ../../layouts/MainLayout.astro
+---
+
+## Online cakes
+
+After installing `cakecutter` you can run
+
+```
+cc cut <cake> <dir>
+```
+
+> `<cake>` is the cake's name and `<dir>` is the directory where the template will be created
+
+to cut an online cake
+
+## Local cakes
+
+You can cut local cakes written in [`toml`](https://toml.io/) syntax files by running
+
+```
+cc local <cake.toml> <dir>
+```
+
+> `cake.toml` is the path to the local cake file and `dir` is the directory where the template will be created
+
+## With npx
+
+If you are using cakecutter through `npx` then just prefix the command with `npx`.
+
+```
+npx cc cut <cake> <dir>
+```

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,4 +2,5 @@
 	// Redirect your homepage to the first page of documentation.
 	// If you have a landing page, remove this script and add it here!
 	window.location.pathname = `/en/introduction`;
+	window.location.pathname = `/es/introduction`;
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,5 +2,4 @@
 	// Redirect your homepage to the first page of documentation.
 	// If you have a landing page, remove this script and add it here!
 	window.location.pathname = `/en/introduction`;
-	window.location.pathname = `/es/introduction`;
 </script>


### PR DESCRIPTION
Add Spanish documentation support. Fixes #5 

- Translated all documents pages for Cakecutter
- Added translation for 'More', 'Overview', and 'Join our community' options

Snippets:

Introduction:

![image](https://user-images.githubusercontent.com/48018975/193430620-f601f9d8-a70a-460c-9aa4-82c73a9fbba7.png)

Installation:

![image](https://user-images.githubusercontent.com/48018975/193430646-00e09cf7-5216-44ca-80ec-dadd7baca617.png)

Using cakes:

![image](https://user-images.githubusercontent.com/48018975/193430663-07159250-e8f8-46dd-a2c9-638694009b03.png)
